### PR TITLE
fixes a typo in two TripDeetails views

### DIFF
--- a/LiveApp/AppViews/Views/TripDetails/TripCell.swift
+++ b/LiveApp/AppViews/Views/TripDetails/TripCell.swift
@@ -9,7 +9,7 @@ struct TripCell: View {
   var body: some View {
     GeometryReader { geometry in
       VStack(alignment: .leading, spacing: 0) {
-        Text(isDestinationEmpty(self.trip) ? "Trip strated from" : "Trip to")
+        Text(isDestinationEmpty(self.trip) ? "Trip started from" : "Trip to")
           .font(
             Font.system(size: 14)
               .weight(.bold))

--- a/LiveApp/AppViews/Views/TripDetails/TripDetails.swift
+++ b/LiveApp/AppViews/Views/TripDetails/TripDetails.swift
@@ -96,7 +96,7 @@ struct TripDetails: View {
     return VStack(spacing: 0.0) {
       HStack {
         VStack(alignment: .leading, spacing: 0) {
-          Text(isDestinationEmpty(self.selectedTrip) ? "Trip strated from" :
+          Text(isDestinationEmpty(self.selectedTrip) ? "Trip started from" :
             "Trip to")
             .font(
               Font.system(size: 14)


### PR DESCRIPTION
“strated” => “started”.

I have no idea how Swift works. Does fixing it here actually fix it? ¯\_(ツ)_/¯
that’s what you get for letting the marketing guy float PRs.